### PR TITLE
chore: pin ip addresses

### DIFF
--- a/media/multimedia/plex.values.yaml
+++ b/media/multimedia/plex.values.yaml
@@ -12,6 +12,7 @@ service:
   type: LoadBalancer
   port: 80
   annotations:
+    metallb.universe.tf/loadBalancerIPs: "10.0.2.8"
     external-dns.alpha.kubernetes.io/hostname: plex.wiersma.tech.
     external-dns.alpha.kubernetes.io/ttl: 5m
 

--- a/mon/influxdb/values.yaml
+++ b/mon/influxdb/values.yaml
@@ -9,6 +9,7 @@ persistence:
 
 service:
   annotations:
+    metallb.universe.tf/loadBalancerIPs: "10.0.2.3"
     external-dns.alpha.kubernetes.io/hostname: influx.wiersma.tech.
     external-dns.alpha.kubernetes.io/ttl: 5m
   type: LoadBalancer


### PR DESCRIPTION
This pins some of the IPs so they can be used directly when DNS is out.